### PR TITLE
Enable autopurge of logs and snapshots

### DIFF
--- a/templates/etc/zookeeper/zoo.cfg
+++ b/templates/etc/zookeeper/zoo.cfg
@@ -23,7 +23,7 @@ clientPort=2181
 # http://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_maintenance
 #
 # The number of snapshots to retain in dataDir
-#autopurge.snapRetainCount=3
+autopurge.snapRetainCount=3
 # Purge task interval in hours
 # Set to "0" to disable auto purge feature
-#autopurge.purgeInterval=1
+autopurge.purgeInterval=1


### PR DESCRIPTION
This should prevent "no more space left on device" errors.